### PR TITLE
Module Manager 3.0.1 compatibility

### DIFF
--- a/Science-Full-reward.cfg
+++ b/Science-Full-reward.cfg
@@ -1,4 +1,4 @@
-@EXPERIMENT_DEFINITION[*]
+@EXPERIMENT_DEFINITION
 {
 	%baseValue = #$scienceCap$
 }


### PR DESCRIPTION
[*] selector was originaly meant for named nodes and is now enforced in the latest MM, so it brake changes for experiments identified by id only. The solution is to remove this selector.