### PR TITLE
1.7.1

### DIFF
--- a/Science-Full-reward.cfg
+++ b/Science-Full-reward.cfg
@@ -1,4 +1,4 @@
-@EXPERIMENT_DEFINITION
+@EXPERIMENT_DEFINITION:HAS[~id[deployed*]]
 {
-	%baseValue = #$scienceCap$
+	@baseValue = #$scienceCap$
 }


### PR DESCRIPTION
Added a bit to exclude the new Breaking Ground deployable experiments since they use baseValue to determine the Science generated per hour. Without this change ground science contracts will fail to be completed.