### PR TITLE
Fix syntax & add pass specifier

### DIFF
--- a/Science-Full-reward.cfg
+++ b/Science-Full-reward.cfg
@@ -1,4 +1,4 @@
-@EXPERIMENT_DEFINITION[*]:HAS[!id[deployed*]]
+@EXPERIMENT_DEFINITION[*]:HAS[~id[deployed*]]:LAST[Science-Full-reward]
 {
 	%baseValue = #$scienceCap$
 }


### PR DESCRIPTION
Replaced ! with ~ in the 'ID' filter. ! is for nodes, ID is a key so you need ~.
Also added LAST[Science-Full-reward] as a pass specifier (Folder name) to get out of the MM legacy pass.